### PR TITLE
fix: losing profile on impersonation threat

### DIFF
--- a/contracts/extending-old/ForkModule.sol
+++ b/contracts/extending-old/ForkModule.sol
@@ -96,7 +96,7 @@ contract ForkModule is IForkModule {
      *  @param _submissionID Address corresponding to the human.
      *  @return expirationTime Expiration time of the revoked humanity.
      */
-    function tryRemove(address _submissionID) external override onlyV2 returns (uint40 expirationTime) {
+    function tryRemove(address _submissionID) external view override onlyV2 returns (uint40 expirationTime) {
         require(!removed[_submissionID], "removed!");
 
         (, uint64 submissionTime, , bool registered, , ) = proofOfHumanityV1.getSubmissionInfo(_submissionID);
@@ -105,7 +105,6 @@ contract ForkModule is IForkModule {
 
         require(registered && block.timestamp < expirationTime && submissionTime < forkTime, "Not registered, expired or submitted after the fork!");
 
-        removed[_submissionID] = true;
     }
 
     /// ====== VIEWS ====== ///

--- a/contracts/interfaces/ICrossChainProofOfHumanity.sol
+++ b/contracts/interfaces/ICrossChainProofOfHumanity.sol
@@ -10,4 +10,6 @@ interface ICrossChainProofOfHumanity {
         uint40 _expirationTime,
         bytes32 _transferHash
     ) external;
+
+    function checkCCTransferCondition(address _owner, bytes20 _humanityId) external;
 }

--- a/contracts/interfaces/IForkModule.sol
+++ b/contracts/interfaces/IForkModule.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.20;
 interface IForkModule {
     function remove(address _submissionID) external;
 
-    function tryRemove(address _submissionID) external returns (uint40);
+    function tryRemove(address _submissionID) external view returns (uint40);
 
     function isRegistered(address _submissionID) external view returns (bool);
 

--- a/contracts/interfaces/IProofOfHumanity.sol
+++ b/contracts/interfaces/IProofOfHumanity.sol
@@ -14,6 +14,13 @@ interface IProofOfHumanity {
 
     /* Views */
 
+    function ccIsHumanityGranteable(
+        bytes20 _humanityId,
+        address _owner
+    ) external view returns (bool success);
+
+    function ccIsHumanityDischargeable(address _owner) external view returns (bytes20 humanityId, uint40 expirationTime);
+
     function isClaimed(bytes20 _humanityId) external view returns (bool);
 
     function isHuman(address _address) external view returns (bool);


### PR DESCRIPTION
If the impersonated requests transferring her profile to the foreign chain, her profile will be removed as a consequence of the unsatisfied conditions on ccGrantHumanity. This update allows avoiding such unwanted side effect if the mentioned edgecase occurs.